### PR TITLE
support ignoring warnings when decrypting pdfs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@neatcapital/node-qpdf2",
-  "version": "2.0.0-neat-fork",
+  "version": "2.1.0-neat-fork",
   "description": "A Content Preserving transformations on PDFs wrapped around QPDF",
   "main": "./dist/index.js",
   "scripts": {
     "pretest": "npm run build",
     "test": "c8 ava --timeout=30s",
     "lint": "eslint '**/*.[jt]s' --cache",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "deploy": "npm run build && npm publish --userconfig=.npmrc"
   },
   "engines": {
     "node": ">=10.17.0"

--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -2,6 +2,7 @@ import { fileExists } from "./utils";
 import execute from "./spawn";
 
 export interface DecryptSettings {
+  ignoreWarnings?: boolean;
   input: string;
   output?: string;
   password?: string;
@@ -12,6 +13,11 @@ export default async (payload: DecryptSettings): Promise<Buffer> => {
   if (!fileExists(payload.input)) throw new Error("Input file doesn't exist");
 
   const callArguments = ["--decrypt"];
+
+  if (payload.ignoreWarnings) {
+    // This will cause qpdf to exit with code 0 instead of 3 when there are warnings
+    callArguments.push(`--warning-exit-0`);
+  }
 
   // Password
   if (payload.password) {


### PR DESCRIPTION
Sometimes pdfs are malformed but are still able to be decrypted.  In this case we don't want qpdf to return with an exit code of 3 as that causes this library to reject as its a non zero exit code.  Fortunately you can pass in the flag
'--warning-exit-0' to qpdf and it will return 0 if there are warnings instead of 3